### PR TITLE
Prevent update reserved schedule available

### DIFF
--- a/fp_app/app/controllers/planners/schedules_controller.rb
+++ b/fp_app/app/controllers/planners/schedules_controller.rb
@@ -16,17 +16,24 @@ class Planners::SchedulesController < ApplicationController
 
   def update
     @schedule = Schedule.find(params[:id])
-    @schedule.is_available = params[:is_available]
-    if @schedule.save
+    if Appointment.exists?(schedule_id: @schedule.id)
       respond_to do |format|
-        format.js { render "planners/schedules/update_schedule" }
+        format.js { render js: "alert('This schedule is associated with an existing appointment and cannot be updated.');" }
       end
     else
-      respond_to do |format|
-        format.js { render js: "alert('Unable to update availability.');" }
+      @schedule.is_available = params[:is_available]
+      if @schedule.save
+        respond_to do |format|
+          format.js { render "planners/schedules/update_schedule" }
+        end
+      else
+        respond_to do |format|
+          format.js { render js: "alert('Unable to update availability.');" }
+        end
       end
     end
   end
+
 
   def create
     @schedule = Schedule.new(

--- a/fp_app/app/controllers/planners/schedules_controller.rb
+++ b/fp_app/app/controllers/planners/schedules_controller.rb
@@ -16,7 +16,7 @@ class Planners::SchedulesController < ApplicationController
 
   def update
     @schedule = Schedule.find(params[:id])
-    if Appointment.exists?(schedule_id: @schedule.id)
+    if Appointment.exists?(schedule_id: @schedule.id, status: "reserved")
       respond_to do |format|
         format.js { render js: "alert('This schedule is associated with an existing appointment and cannot be updated.');" }
       end

--- a/fp_app/app/controllers/planners/schedules_controller.rb
+++ b/fp_app/app/controllers/planners/schedules_controller.rb
@@ -16,7 +16,7 @@ class Planners::SchedulesController < ApplicationController
 
   def update
     @schedule = Schedule.find(params[:id])
-    if Appointment.exists?(schedule_id: @schedule.id, status: "reserved")
+    if @schedule.appointment.exists?(status: "reserved")
       respond_to do |format|
         format.js { render js: "alert('This schedule is associated with an existing appointment and cannot be updated.');" }
       end

--- a/fp_app/app/controllers/planners/schedules_controller.rb
+++ b/fp_app/app/controllers/planners/schedules_controller.rb
@@ -34,7 +34,6 @@ class Planners::SchedulesController < ApplicationController
     end
   end
 
-
   def create
     @schedule = Schedule.new(
       planner_id: @planner.id,

--- a/fp_app/app/controllers/planners/schedules_controller.rb
+++ b/fp_app/app/controllers/planners/schedules_controller.rb
@@ -16,7 +16,7 @@ class Planners::SchedulesController < ApplicationController
 
   def update
     @schedule = Schedule.find(params[:id])
-    if @schedule.appointment.exists?(status: "reserved")
+    if @schedule.appointments.exists?(status: "reserved")
       respond_to do |format|
         format.js { render js: "alert('This schedule is associated with an existing appointment and cannot be updated.');" }
       end

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -17,7 +17,7 @@ module SchedulesHelper
       matching_schedule = schedules.find { |s| s.started_at.to_date == day && s.started_at.strftime("%H:%M") == time }
 
       if matching_schedule
-        is_reserved = Appointment.exists?(schedule_id: matching_schedule.id, status: "reserved")
+        is_reserved = matching_schedule.appointment.exists?(status: "reserved")
         link_to(is_reserved ? "&#x2612;".html_safe: (matching_schedule.is_available ? "&#9711;".html_safe: "&#10005;".html_safe), planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
           method: :patch, remote: true, class: "toggle-availability",
           data: { schedule_id: matching_schedule.id },

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -30,5 +30,4 @@ module SchedulesHelper
       end
     end
   end
-
 end

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -21,12 +21,12 @@ module SchedulesHelper
         link_to(is_reserved ? "&#x2612;".html_safe: (matching_schedule.is_available ? "&#9711;".html_safe: "&#10005;".html_safe), planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
           method: :patch, remote: true, class: "toggle-availability",
           data: { schedule_id: matching_schedule.id },
-          style: "font-size: #{is_reserved ? '30px' : '24px'}; color: #{matching_schedule.is_available ? '#4CAF50' : '#FF0000'};")
+          style: "font-size: #{is_reserved ? '30px' : '24px'}; color: #{is_reserved ? '#FF0000' : '#111111'};")
       else
         link_to("--", planner_schedules_path(planner_id: @planner.id, date: day, time: time),
                 method: :post, remote: true, class: "toggle-availability",
                 data: { schedule_id: nil, date: day.strftime("%Y-%m-%d"), time: time },
-                style: "font-size: 24px; color: #FF0000;")
+                style: "font-size: 24px; color: #111111;")
       end
     end
   end

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -15,11 +15,13 @@ module SchedulesHelper
       content_tag(:span, "--", style: "background-color: black; color: white; font-size: 24px; padding: 10px;")
     else
       matching_schedule = schedules.find { |s| s.started_at.to_date == day && s.started_at.strftime("%H:%M") == time }
+
       if matching_schedule
+        is_reserved = Appointment.exists?(schedule_id: matching_schedule.id, status: "reserved")
         link_to(matching_schedule.is_available ? "◯" : "✖️", planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
-                method: :patch, remote: true, class: "toggle-availability",
-                data: { schedule_id: matching_schedule.id },
-                style: "font-size: 24px; color: #{matching_schedule.is_available ? '#4CAF50' : '#FF0000'};")
+          method: :patch, remote: true, class: "toggle-availability",
+          data: { schedule_id: matching_schedule.id },
+          style: "font-size: 24px; color: #{is_reserved ? '#4CAF50' : (matching_schedule.is_available ? '#4CAF50' : '#FF0000')};")
       else
         link_to("--", planner_schedules_path(planner_id: @planner.id, date: day, time: time),
                 method: :post, remote: true, class: "toggle-availability",
@@ -28,4 +30,5 @@ module SchedulesHelper
       end
     end
   end
+
 end

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -18,10 +18,10 @@ module SchedulesHelper
 
       if matching_schedule
         is_reserved = Appointment.exists?(schedule_id: matching_schedule.id, status: "reserved")
-        link_to(matching_schedule.is_available ? "◯" : "✖️", planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
+        link_to(is_reserved ? "&#x2612;".html_safe: (matching_schedule.is_available ? "&#9711;".html_safe: "&#10005;".html_safe), planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
           method: :patch, remote: true, class: "toggle-availability",
           data: { schedule_id: matching_schedule.id },
-          style: "font-size: 24px; color: #{is_reserved ? '#4CAF50' : (matching_schedule.is_available ? '#4CAF50' : '#FF0000')};")
+          style: "font-size: #{is_reserved ? '30px' : '24px'}; color: #{matching_schedule.is_available ? '#4CAF50' : '#FF0000'};")
       else
         link_to("--", planner_schedules_path(planner_id: @planner.id, date: day, time: time),
                 method: :post, remote: true, class: "toggle-availability",

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -17,7 +17,7 @@ module SchedulesHelper
       matching_schedule = schedules.find { |s| s.started_at.to_date == day && s.started_at.strftime("%H:%M") == time }
 
       if matching_schedule
-        is_reserved = matching_schedule.check_last_appointment
+        is_reserved = matching_schedule.latest_appointment_reserved?
         link_to(is_reserved ? "&#x2612;".html_safe: (matching_schedule.is_available ? "&#9711;".html_safe: "&#10005;".html_safe), planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
           method: :patch, remote: true, class: "toggle-availability",
           data: { schedule_id: matching_schedule.id },

--- a/fp_app/app/helpers/schedules_helper.rb
+++ b/fp_app/app/helpers/schedules_helper.rb
@@ -17,7 +17,7 @@ module SchedulesHelper
       matching_schedule = schedules.find { |s| s.started_at.to_date == day && s.started_at.strftime("%H:%M") == time }
 
       if matching_schedule
-        is_reserved = matching_schedule.appointment.exists?(status: "reserved")
+        is_reserved = matching_schedule.check_last_appointment
         link_to(is_reserved ? "&#x2612;".html_safe: (matching_schedule.is_available ? "&#9711;".html_safe: "&#10005;".html_safe), planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
           method: :patch, remote: true, class: "toggle-availability",
           data: { schedule_id: matching_schedule.id },

--- a/fp_app/app/models/appointment.rb
+++ b/fp_app/app/models/appointment.rb
@@ -13,10 +13,6 @@ class Appointment < ApplicationRecord
 
   enum status: { reserved: 0, canceled: 1, done: 2, expired: 3 }, _prefix: true
 
-  def check_reserved_appointment
-    status_reserved?
-  end
-
   private
 
   def check_reserved_at_is_future_or_present

--- a/fp_app/app/models/appointment.rb
+++ b/fp_app/app/models/appointment.rb
@@ -13,6 +13,10 @@ class Appointment < ApplicationRecord
 
   enum status: { reserved: 0, canceled: 1, done: 2, expired: 3 }, _prefix: true
 
+  def check_reserved_appointment
+    status_reserved?
+  end
+
   private
 
   def check_reserved_at_is_future_or_present

--- a/fp_app/app/models/schedule.rb
+++ b/fp_app/app/models/schedule.rb
@@ -7,9 +7,10 @@ class Schedule < ApplicationRecord
   WORKING_HOURS_SATURDAY = { start: 11, end: 15 }.freeze
   WORKING_HOURS_WEEKDAYS = { start: 10, end: 18 }.freeze
 
-  def check_last_appointment
+  def latest_appointment_reserved?
     last_appointment = appointments.last
-    last_appointment.check_reserved_appointment if last_appointment
+    return false if last_appointment.nil?
+    last_appointment.status_reserved?
   end
 
   private

--- a/fp_app/app/models/schedule.rb
+++ b/fp_app/app/models/schedule.rb
@@ -9,11 +9,7 @@ class Schedule < ApplicationRecord
 
   def check_last_appointment
     last_appointment = appointments.last
-    check_reserved_appointment(last_appointment)
-  end
-
-  def check_reserved_appointment(appointment)
-    appointment && appointment.status_reserved?
+    last_appointment.check_reserved_appointment if last_appointment
   end
 
   private

--- a/fp_app/app/models/schedule.rb
+++ b/fp_app/app/models/schedule.rb
@@ -1,6 +1,6 @@
 class Schedule < ApplicationRecord
   belongs_to :planner
-  has_one :appointment
+  has_many :appointment
   validates :planner_id, presence: true
   validate :check_started_at_future_or_present
   validate :check_schedule_within_working_hours

--- a/fp_app/app/models/schedule.rb
+++ b/fp_app/app/models/schedule.rb
@@ -1,11 +1,20 @@
 class Schedule < ApplicationRecord
   belongs_to :planner
-  has_many :appointment
+  has_many :appointments
   validates :planner_id, presence: true
   validate :check_started_at_future_or_present
   validate :check_schedule_within_working_hours
   WORKING_HOURS_SATURDAY = { start: 11, end: 15 }.freeze
   WORKING_HOURS_WEEKDAYS = { start: 10, end: 18 }.freeze
+
+  def check_last_appointment
+    last_appointment = appointments.last
+    check_reserved_appointment(last_appointment)
+  end
+
+  def check_reserved_appointment(appointment)
+    appointment && appointment.status_reserved?
+  end
 
   private
 

--- a/fp_app/app/views/planners/schedules/update_schedule.js.erb
+++ b/fp_app/app/views/planners/schedules/update_schedule.js.erb
@@ -11,4 +11,3 @@ if (button.length > 0) {
   newButton.attr("href", "<%= planner_schedule_path(planner_id: @planner.id, id: @schedule.id, is_available: !@schedule.is_available) %>");
   newButton.attr("data-method", "patch");
 }
-s

--- a/fp_app/app/views/planners/schedules/update_schedule.js.erb
+++ b/fp_app/app/views/planners/schedules/update_schedule.js.erb
@@ -1,11 +1,11 @@
 var button = $("[data-schedule-id='<%= @schedule.id %>']");
 if (button.length > 0) {
-  button.text("<%= @schedule.is_available ? '◯' : '✖️' %>");
+  button.html("<%= @schedule.is_available ? '&#9711;'.html_safe : '&#10005;'.html_safe %>");
   button.css("color", "<%= @schedule.is_available ? '#4CAF50' : '#FF0000' %>");
   button.attr("href", "<%= planner_schedule_path(planner_id: @schedule.planner_id, id: @schedule.id, is_available: !@schedule.is_available) %>");
 } else {
   var newButton = $("[data-date='<%= @schedule.started_at.strftime('%Y-%m-%d') %>'][data-time='<%= @schedule.started_at.strftime('%H:%M') %>']");
-  newButton.text("<%= @schedule.is_available ? '◯' : '✖️' %>");
+  newButton.html("<%= @schedule.is_available ? '&#9711;'.html_safe : '&#10005;'.html_safe %>");
   newButton.css("color", "<%= @schedule.is_available ? '#4CAF50' : '#FF0000' %>");
   newButton.attr("data-schedule-id", "<%= @schedule.id %>");
   newButton.attr("href", "<%= planner_schedule_path(planner_id: @planner.id, id: @schedule.id, is_available: !@schedule.is_available) %>");

--- a/fp_app/app/views/planners/schedules/update_schedule.js.erb
+++ b/fp_app/app/views/planners/schedules/update_schedule.js.erb
@@ -1,12 +1,12 @@
 var button = $("[data-schedule-id='<%= @schedule.id %>']");
 if (button.length > 0) {
   button.html("<%= @schedule.is_available ? '&#9711;'.html_safe : '&#10005;'.html_safe %>");
-  button.css("color", "<%= @schedule.is_available ? '#4CAF50' : '#FF0000' %>");
+  button.css("color", "<%= @schedule.is_available ? '#111111' : '#111111' %>");
   button.attr("href", "<%= planner_schedule_path(planner_id: @schedule.planner_id, id: @schedule.id, is_available: !@schedule.is_available) %>");
 } else {
   var newButton = $("[data-date='<%= @schedule.started_at.strftime('%Y-%m-%d') %>'][data-time='<%= @schedule.started_at.strftime('%H:%M') %>']");
   newButton.html("<%= @schedule.is_available ? '&#9711;'.html_safe : '&#10005;'.html_safe %>");
-  newButton.css("color", "<%= @schedule.is_available ? '#4CAF50' : '#FF0000' %>");
+  newButton.css("color", "<%= @schedule.is_available ? '#111111' : '#111111' %>");
   newButton.attr("data-schedule-id", "<%= @schedule.id %>");
   newButton.attr("href", "<%= planner_schedule_path(planner_id: @planner.id, id: @schedule.id, is_available: !@schedule.is_available) %>");
   newButton.attr("data-method", "patch");

--- a/fp_app/app/views/simple_calendar/_appointment_week_calendar.html.slim
+++ b/fp_app/app/views/simple_calendar/_appointment_week_calendar.html.slim
@@ -34,15 +34,15 @@ div.simple-calendar
                   - matching_schedule = @schedules.find { |s| s.started_at.to_date == day && s.started_at.strftime("%H:%M") == time }
                   - if matching_schedule
                     - if matching_schedule.is_available
-                      = link_to "◯", planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id), class: "toggle-availability",
+                      = link_to '&#9711;'.html_safe, planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id), class: "toggle-availability",
                                 style: "font-size: 24px; color: #4CAF50;"
                     - else
-                      = link_to "✖️", planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
+                      = link_to '&#10005;'.html_safe, planner_schedule_path(planner_id: @planner.id, id: matching_schedule.id, is_available: !matching_schedule.is_available),
                                 method: :patch, remote: true, class: "toggle-availability",
                                 data: { schedule_id: matching_schedule.id },
                                 style: "font-size: 24px; color: #FF0000;"
                   - else
-                    = link_to "✖️", planner_schedules_path(planner_id: @planner.id, date: day, time: time),
+                    = link_to '&#10005;'.html_safe, planner_schedules_path(planner_id: @planner.id, date: day, time: time),
                               method: :post, remote: true, class: "toggle-availability",
                               data: { schedule_id: nil, date: day.strftime("%Y-%m-%d"), time: time },
                               style: "font-size: 24px; color: #FF0000;"

--- a/fp_app/spec/helpers/schedules_helper_spec.rb
+++ b/fp_app/spec/helpers/schedules_helper_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe SchedulesHelper, type: :helper do
       it 'returns the correct availability link for available schedule' do
         weekday = schedule_on_weekday.started_at.to_date
         time = schedule_on_weekday.started_at.strftime("%H:%M")
-        expect(helper.matching_schedule_or_blackout(weekday, time, schedules)).to include('◯')
+        expect(helper.matching_schedule_or_blackout(weekday, time, schedules)).to include('&#9711;')
       end
 
       it 'returns the correct availability link for unavailable schedule' do
         weekday = schedule_on_weekday_unavailable.started_at.to_date
         time = schedule_on_weekday_unavailable.started_at.strftime("%H:%M")
-        expect(helper.matching_schedule_or_blackout(weekday, time, schedules)).to include('✖️')
+        expect(helper.matching_schedule_or_blackout(weekday, time, schedules)).to include('&#10005;')
       end
     end
 
@@ -47,7 +47,7 @@ RSpec.describe SchedulesHelper, type: :helper do
       it 'returns the correct availability link for an available time slot outside blackout hours' do
         saturday = schedule_on_saturday.started_at.to_date
         time = schedule_on_saturday.started_at.strftime("%H:%M")
-        expect(helper.matching_schedule_or_blackout(saturday, time, schedules)).to include('◯')
+        expect(helper.matching_schedule_or_blackout(saturday, time, schedules)).to include('&#9711;')
       end
     end
 

--- a/fp_app/spec/models/appointment_spec.rb
+++ b/fp_app/spec/models/appointment_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Appointment, type: :model do
 
     it 'is invalid when the planner is not available' do
       appointment = build(:appointment, user: user, schedule: schedule, planner: planner)
-      schedule.update(is_available: false)
+      expect(appointment).not_to be_valid
       expect(appointment.errors[:schedule_id]).to include("is not available at the selected time")
     end
 

--- a/fp_app/spec/models/schedule_spec.rb
+++ b/fp_app/spec/models/schedule_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Schedule, type: :model do
   let(:planner) { create(:planner) }
   let(:schedule) { create(:schedule, planner: planner) }
   let(:reserved_schedule) { create(:schedule, :reserved_schedule, planner: planner) }
-  let(:canceled_appointment) {create(:appointment, user: user, planner: planner, schedule: reserved_schedule, reserved_at: reserved_schedule.started_at, status: "canceled")}
-  let(:appointment) {create(:appointment, user: user, planner: planner, schedule: reserved_schedule, reserved_at: reserved_schedule.started_at, status: "reserved")}
+  let(:canceled_appointment) { create(:appointment, user: user, planner: planner, schedule: reserved_schedule, reserved_at: reserved_schedule.started_at, status: "canceled") }
+  let(:appointment) { create(:appointment, user: user, planner: planner, schedule: reserved_schedule, reserved_at: reserved_schedule.started_at, status: "reserved") }
 
   describe 'validations' do
     it 'is valid with valid attributes' do
@@ -82,7 +82,9 @@ RSpec.describe Schedule, type: :model do
       schedule = build(:schedule, planner: planner, started_at: saturday_between, is_available: true)
       expect(schedule).to be_valid
     end
+  end
 
+  describe 'latest_appointment_reserved?' do
     it 'returns latest_appointment' do
       canceled_appointment
       appointment

--- a/fp_app/spec/models/schedule_spec.rb
+++ b/fp_app/spec/models/schedule_spec.rb
@@ -1,9 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Schedule, type: :model do
+  let(:user) { create(:user) }
   let(:planner) { create(:planner) }
   let(:schedule) { create(:schedule, planner: planner) }
   let(:reserved_schedule) { create(:schedule, :reserved_schedule, planner: planner) }
+  let(:canceled_appointment) {create(:appointment, user: user, planner: planner, schedule: reserved_schedule, reserved_at: reserved_schedule.started_at, status: "canceled")}
+  let(:appointment) {create(:appointment, user: user, planner: planner, schedule: reserved_schedule, reserved_at: reserved_schedule.started_at, status: "reserved")}
 
   describe 'validations' do
     it 'is valid with valid attributes' do
@@ -78,6 +81,12 @@ RSpec.describe Schedule, type: :model do
       saturday_between = (Time.now.next_occurring(:saturday).beginning_of_day + 1.week) + 12.hours
       schedule = build(:schedule, planner: planner, started_at: saturday_between, is_available: true)
       expect(schedule).to be_valid
+    end
+
+    it 'returns latest_appointment' do
+      canceled_appointment
+      appointment
+      expect(reserved_schedule.latest_appointment_reserved?).to eq(true)
     end
   end
 end

--- a/fp_app/spec/requests/planners/schedules_spec.rb
+++ b/fp_app/spec/requests/planners/schedules_spec.rb
@@ -81,13 +81,13 @@ RSpec.describe "Planners::Schedules", type: :request do
     context "when schedule is associated with a reserved appointment" do
       it "does not update the schedule and shows an alert" do
         post appointments_path, params: {
-              appointment: {
-                user_id: user.id,
-                planner_id: planner.id,
-                schedule_id: available_schedule.id,
-                reserved_at: available_schedule.started_at,
-                status: "reserved"
-              }
+          appointment: {
+            user_id: user.id,
+            planner_id: planner.id,
+            schedule_id: available_schedule.id,
+            reserved_at: available_schedule.started_at,
+            status: "reserved"
+          }
         }
         expect(available_schedule.reload.is_available).to be_falsey
 

--- a/fp_app/spec/requests/planners/schedules_spec.rb
+++ b/fp_app/spec/requests/planners/schedules_spec.rb
@@ -97,7 +97,6 @@ RSpec.describe "Planners::Schedules", type: :request do
         }.not_to change { available_schedule.is_available }
 
         expect(available_schedule.reload.is_available).to be_falsey
-
       end
     end
   end


### PR DESCRIPTION
planner側のスケジュール更新ページでuserからの予約が入った日時はスケジュールを更新できないようにしました。
具体的には以下の機能を追加しました。
今までの実装だとuserが予約を作成すると、plannerのscheduleのis_availableの値も反転するが、planner側のschedule更新ページで予約が入った時間のis_availableを更新すると更新がでいてしまう。
そこで予約が入った時間でかつ予約のstatusが"reserved"のままの状態だと更新ができないように設定しました。

以下にエラーが出るまでのUI画面を示します。

------------------------------------------------------------------------------------------------
user側のマイページ（予約履歴閲覧画面）
<img width="940" alt="スクリーンショット 2024-10-30 16 45 10" src="https://github.com/user-attachments/assets/e1a89180-167d-46d3-b23f-5e28809bcf6c">

ここではfp_ex1に対して2024/11/08 11:00に予約を行なっている。

-----------------------------------------------------------------------------------------------
planner側のスケジュール更新ページ
<img width="1240" alt="スクリーンショット 2024-10-30 16 47 53" src="https://github.com/user-attachments/assets/9a09443d-cb9a-4c84-ad2f-4fee7308ff50">

fp_ex1のスケジュールで2024/11/08 11:00にis_availableの値がfalseになっていることがわかる。

-----------------------------------------------------------------------------------------------
plannerが予約が入った時間のis_avaulableを更新しようとする
<img width="1275" alt="スクリーンショット 2024-10-30 16 49 09" src="https://github.com/user-attachments/assets/518d12df-23fd-4aa2-b688-6fb46a2492b9">

予約が入っている時間を更新するとエラーが出て更新できなくなっていることがわかる。

-----------------------------------------------------------------------------------------------

今回確認をお願いしたいファイルを以下に示します。

- app/controllers/planners/schedules_controller.rb
- spec/requests/planners/schedules_spec.rb

よろしくお願いします。






