### PR TITLE
Install crontab

### DIFF
--- a/fp_app/Dockerfile.dev
+++ b/fp_app/Dockerfile.dev
@@ -8,6 +8,7 @@ COPY Gemfile Gemfile.lock /app/
 
 # 依存関係をインストール
 RUN bundle install
+RUN apt-get update && apt-get install -y cron
 
 COPY entrypoint.sh /usr/bin/
 RUN chmod +x /usr/bin/entrypoint.sh


### PR DESCRIPTION
非同期処理を行うwhenever gem を使う際にcrontabが必要になるので、dockerfileにcrontabをインストールするコマンドを追加しています。

※wheneverで定期実行させたいjobや頻度を指定し、その内容をcronにアップデートする流れになっています。

インストール後は以下のようにcrontabが正常に動いてることがわかります。
<img width="450" alt="スクリーンショット 2024-11-13 10 53 17" src="https://github.com/user-attachments/assets/94f8ad99-c2cb-4a56-b135-ba2308eb8895">
