### PR TITLE
Add search planner function

### DIFF
--- a/fp_app/Gemfile
+++ b/fp_app/Gemfile
@@ -12,6 +12,7 @@ gem "redis-rails"
 gem "sidekiq"
 gem "whenever", require: false
 gem "kaminari"
+gem "ransack"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"

--- a/fp_app/Gemfile.lock
+++ b/fp_app/Gemfile.lock
@@ -251,6 +251,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.7.0)
       psych (>= 4.0.0)
     redis (5.3.0)
@@ -428,6 +432,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.0)
   rails-controller-testing
+  ransack
   redis (>= 4.0.1)
   redis-rails
   ridgepole

--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -7,7 +7,12 @@ class PlannersController < ApplicationController
   SHOW_ITEMS_PER_PAGE = 7
 
   def index
-    @planners = Planner.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    @q = Planner.ransack(params[:q])
+    if params[:q].present?
+      @planners = @q.result(distinct: true).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    else
+      @planners = Planner.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    end
   end
 
   def show

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -4,4 +4,8 @@ class Planner < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
   has_many :schedules, dependent: :destroy
   has_many :appointments, dependent: :destroy
+
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name]
+  end
 end

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -4,17 +4,23 @@
 
   h2 FP List
 
+  = search_form_for @q, url: planners_path, method: :get do |f|
+    .form-group.d-flex.justify-content-between.align-items-center style="margin-bottom: 20px;"
+      = f.label :name_cont, "Search by name", style: "margin-right: 10px; font-weight: bold;"
+      = f.search_field :name_cont, class: "form-control", style: "width: 70%; margin-right: 10px;"
+      = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; padding: 10px 20px; border-radius: 5px;"
+
   .list-group
     - @planners.each do |planner|
       .list-group-item.d-flex.justify-content-between.align-items-center.mb-4 style="border: 1px solid #000; border-radius: 10px; padding: 15px; margin-bottom: 20px;"
         .d-flex.align-items-center
           div style="display: flex; align-items: center;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
-            = link_to planner.name, planner_path(planner.id), class: 'planner-name-link'
+            = link_to truncate(planner.name, length: 20), planner_path(planner.id), class: 'planner-name-link'
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px; margin-left: auto; margin-right: 30px;"
 
   .pagination-wrapper
-    = paginate @planners,window: 2
+    = paginate @planners, window: 2
 
 style
   |
@@ -46,6 +52,6 @@ style
     }
 
     .pagination .current {
-      color: #4EA1D3;
+      color: ##111111;
       font-weight: bold;
     }

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -7,9 +7,7 @@
   = search_form_for @q, url: planners_path, method: :get do |f|
     div style="display: flex; align-items: center; margin-bottom: 20px;"
       =f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
-      =f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: auto; height: 38px;"
-
-
+      =f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: auto; hei"
 
   .list-group
     - @planners.each do |planner|

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -5,10 +5,11 @@
   h2 FP List
 
   = search_form_for @q, url: planners_path, method: :get do |f|
-    .form-group.d-flex.justify-content-between.align-items-center style="margin-bottom: 20px;"
-      = f.label :name_cont, "Search by name", style: "margin-right: 10px; font-weight: bold;"
-      = f.search_field :name_cont, class: "form-control", style: "width: 70%; margin-right: 10px;"
-      = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; padding: 10px 20px; border-radius: 5px;"
+    div style="display: flex; align-items: center; margin-bottom: 20px;"
+      =f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
+      =f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: auto; height: 38px;"
+
+
 
   .list-group
     - @planners.each do |planner|


### PR DESCRIPTION
plannerの名前でplannerを検索する機能をFP Listのページに追加しました。
具体的には以下の作業を可能にしました

1. userが検索したいplannerの名前を検索フィールドに入力
2. 検索フィールドに入力された文字の名前に部分一致しるplannerの一覧を表示する

実際の動作画面を以下に示します。

--------------------------------------------------------------------------------------------
https://github.com/user-attachments/assets/4dc398cd-bf92-4f77-8ee3-20b735844812

--------------------------------------------------------------------------------------------
今回確認して欲しいファイルを以下に示します。

- app/controllers/planners_controller.rb
- app/models/planner.rb
- app/views/planners/index.html.slim

よろしくお願いします🙇
