### PR TITLE
Sort planner list

### DIFF
--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -12,8 +12,6 @@ class PlannersController < ApplicationController
     case params[:sort]
     when "total_of_consultations"
       @planners = searched_planners.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
-    when "order_of_registration"
-      @planners = searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     else
       @planners = searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     end

--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -7,15 +7,15 @@ class PlannersController < ApplicationController
   ITEMS_PER_PAGE_FOR_SHOW = 7
 
   def index
-    @search_word = Planner.ransack(params[:name_cont] ? { name_cont: params[:name_cont] } : nil)
-    @searched_planners = @search_word.result(distinct: true)
+    search_word = Planner.ransack(params[:name_cont] ? { name_cont: params[:name_cont] } : nil)
+    searched_planners = search_word.result(distinct: true)
     case params[:sort]
     when "total_of_consultations"
-      @planners = @searched_planners.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+      @planners = searched_planners.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     when "order_of_registration"
-      @planners = @searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+      @planners = searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     else
-      @planners = @searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+      @planners = searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     end
   end
 

--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -7,13 +7,13 @@ class PlannersController < ApplicationController
   ITEMS_PER_PAGE_FOR_SHOW = 7
 
   def index
-    @q = Planner.ransack(params[:q])
-    if params[:q].present?
-      @planners = @q.result(distinct: true).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
-    elsif params[:with_done_appointments].present?
-      @planners = Planner.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
-    else
-      @planners = Planner.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    @search_word = Planner.ransack(params[:name_cont] ? { name_cont: params[:name_cont] } : nil)
+    @searched_planners = @search_word.result(distinct: true)
+    case params[:sort]
+    when "total_of_consultations"
+      @planners = @searched_planners.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    when "order_of_registration"
+      @planners = @searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     end
   end
 

--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -14,6 +14,8 @@ class PlannersController < ApplicationController
       @planners = @searched_planners.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     when "order_of_registration"
       @planners = @searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    else
+      @planners = @searched_planners.order(:created_at).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     end
   end
 

--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -7,7 +7,8 @@ class PlannersController < ApplicationController
   ITEMS_PER_PAGE_FOR_SHOW = 7
 
   def index
-    search_word = Planner.ransack(params[:name_cont] ? { name_cont: params[:name_cont] } : nil)
+    search_word_params = params[:name_cont] ? { name_cont: params[:name_cont] } : nil
+    search_word = Planner.ransack(search_word_params)
     searched_planners = search_word.result(distinct: true)
     case params[:sort]
     when "total_of_consultations"

--- a/fp_app/app/controllers/planners_controller.rb
+++ b/fp_app/app/controllers/planners_controller.rb
@@ -10,6 +10,8 @@ class PlannersController < ApplicationController
     @q = Planner.ransack(params[:q])
     if params[:q].present?
       @planners = @q.result(distinct: true).page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
+    elsif params[:with_done_appointments].present?
+      @planners = Planner.with_done_appointments.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     else
       @planners = Planner.page(params[:page]).per(ITEMS_PER_PAGE_FOR_INDEX)
     end

--- a/fp_app/app/helpers/planners_helper.rb
+++ b/fp_app/app/helpers/planners_helper.rb
@@ -1,8 +1,8 @@
 module PlannersHelper
   def sort_option(name_cont)
     [
-      ['Order of registration', planners_path(sort: 'order_of_registration', name_cont: name_cont)],
-      ['Total of Consultations', planners_path(sort: 'total_of_consultations', name_cont: name_cont)]
+      [ "Order of registration", planners_path(sort: "order_of_registration", name_cont: name_cont) ],
+      [ "Total of Consultations", planners_path(sort: "total_of_consultations", name_cont: name_cont) ]
     ]
   end
 end

--- a/fp_app/app/helpers/planners_helper.rb
+++ b/fp_app/app/helpers/planners_helper.rb
@@ -1,8 +1,8 @@
 module PlannersHelper
-  def sort_option(params)
+  def sort_option(name_cont)
     [
-      ['Order of registration', planners_path(sort: 'order_of_registration', name_cont: params[:name_cont])],
-      ['Total of Consultations', planners_path(sort: 'total_of_consultations', name_cont: params[:name_cont])]
+      ['Order of registration', planners_path(sort: 'order_of_registration', name_cont: name_cont)],
+      ['Total of Consultations', planners_path(sort: 'total_of_consultations', name_cont: name_cont)]
     ]
   end
 end

--- a/fp_app/app/helpers/planners_helper.rb
+++ b/fp_app/app/helpers/planners_helper.rb
@@ -1,0 +1,8 @@
+module PlannersHelper
+  def sort_option(params)
+    [
+      ['Order of registration', planners_path(sort: 'order_of_registration', name_cont: params[:name_cont])],
+      ['Total of Consultations', planners_path(sort: 'total_of_consultations', name_cont: params[:name_cont])]
+    ]
+  end
+end

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -7,7 +7,7 @@ class Planner < ApplicationRecord
 
   scope :with_done_appointments, -> {
     left_joins(:appointments)
-    .select("planners.*, SUM(CASE WHEN appointments.status = #{Appointment.statuses[:done]} THEN 1 ELSE 0 END) AS done_appointments_count")
+      .select("planners.*, SUM(CASE WHEN appointments.status = #{Appointment.statuses[:done]} THEN 1 ELSE 0 END) AS done_appointments_count")
       .group("planners.id")
       .order("done_appointments_count DESC, planners.id ASC")
   }

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -5,7 +5,18 @@ class Planner < ApplicationRecord
   has_many :schedules, dependent: :destroy
   has_many :appointments, dependent: :destroy
 
+  scope :with_done_appointments, -> {
+    joins(:appointments)
+      .where(appointments: { status: "done" })
+      .group("planners.id")
+      .order("COUNT(appointments.id) DESC")
+  }
+
   def self.ransackable_attributes(auth_object = nil)
     %w[name]
+  end
+
+  def count_done_appointment
+    appointments.where(status: "done").count
   end
 end

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -17,6 +17,10 @@ class Planner < ApplicationRecord
     %w[name]
   end
 
+  def self.ransackable_associations(auth_object = nil)
+    %w[appointments]
+  end
+
   def count_done_appointment
     appointments.where(status: "done").count
   end

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -4,11 +4,10 @@ class Planner < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
   has_many :schedules, dependent: :destroy
   has_many :appointments, dependent: :destroy
-  DONE = 2
 
   scope :with_done_appointments, -> {
     left_joins(:appointments)
-      .select("planners.*, SUM(CASE WHEN appointments.status = #{DONE} THEN 1 ELSE 0 END) AS done_appointments_count")
+    .select("planners.*, SUM(CASE WHEN appointments.status = #{Appointment.statuses[:done]} THEN 1 ELSE 0 END) AS done_appointments_count")
       .group("planners.id")
       .order("done_appointments_count DESC, planners.id ASC")
   }

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -20,7 +20,7 @@ class Planner < ApplicationRecord
     %w[appointments]
   end
 
-  def count_done_appointment
-    appointments.where(status: "done").count
+  def done_appointments_count
+    appointments.status_done.count
   end
 end

--- a/fp_app/app/models/planner.rb
+++ b/fp_app/app/models/planner.rb
@@ -4,12 +4,13 @@ class Planner < ApplicationRecord
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
   has_many :schedules, dependent: :destroy
   has_many :appointments, dependent: :destroy
+  DONE = 2
 
   scope :with_done_appointments, -> {
-    joins(:appointments)
-      .where(appointments: { status: "done" })
+    left_joins(:appointments)
+      .select("planners.*, SUM(CASE WHEN appointments.status = #{DONE} THEN 1 ELSE 0 END) AS done_appointments_count")
       .group("planners.id")
-      .order("COUNT(appointments.id) DESC")
+      .order("done_appointments_count DESC, planners.id ASC")
   }
 
   def self.ransackable_attributes(auth_object = nil)

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -12,7 +12,7 @@
 
   div style="display: flex; align-items: center; margin-bottom: 20px;"
     = select_tag 'sort_order',
-      options_for_select(sort_option(params), planners_path(sort: params[:sort], name_cont: params[:name_cont])),
+      options_for_select(sort_option(params[:name_cont]), planners_path(sort: params[:sort], name_cont: params[:name_cont])),
       onchange: 'location = this.value;',
       class: "form-control",
       style: "height: 38px; margin: auto 0; line-height: 34px;"

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -8,7 +8,11 @@
     div style="display: flex; align-items: center; margin-bottom: 20px;"
       = f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
       = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px; margin-right: 10px;"
-      = link_to 'Total sort', planners_path(with_done_appointments: true), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px; margin: auto 0; line-height: 34px;"
+      = select_tag 'sort_order',options_for_select([['Order of registration', planners_path],['Total sort', planners_path(with_done_appointments: true)]]),
+        onchange: 'location = this.value;',
+        class: "form-control",
+        style: "height: 38px; margin: auto 0; line-height: 34px;"
+
 
   .list-group
     - @planners.each do |planner|
@@ -18,7 +22,7 @@
           div style="display: flex; align-items: center; flex-grow: 1;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
             = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
-            span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total: #{done_count})"
+            span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Reservations: #{done_count})"
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"
 
   .pagination-wrapper

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -27,7 +27,6 @@
           div style="display: flex; align-items: center; flex-grow: 1;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
             = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
-            = planner.id
             span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Consultations: #{done_count})"
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"
 

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -8,10 +8,12 @@
     div style="display: flex; align-items: center; margin-bottom: 20px;"
       = f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
       = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px; margin-right: 10px;"
-      = select_tag 'sort_order',options_for_select([['Order of registration', planners_path],['Total sort', planners_path(with_done_appointments: true)]]),
+      = select_tag 'sort_order', options_for_select([['Order of registration', planners_path],['Total of Consultations', planners_path(with_done_appointments: true)]],
+        selected: planners_path(with_done_appointments: params[:with_done_appointments])),
         onchange: 'location = this.value;',
         class: "form-control",
         style: "height: 38px; margin: auto 0; line-height: 34px;"
+
 
 
   .list-group
@@ -22,7 +24,7 @@
           div style="display: flex; align-items: center; flex-grow: 1;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
             = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
-            span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Reservations: #{done_count})"
+            span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Consultations: #{done_count})"
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"
 
   .pagination-wrapper

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -4,17 +4,20 @@
 
   h2 FP List
 
-  = search_form_for @q, url: planners_path, method: :get do |f|
+  = form_with url: planners_path, method: :get, local: true do |f|
     div style="display: flex; align-items: center; margin-bottom: 20px;"
-      = f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
-      = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px; margin-right: 10px;"
-      = select_tag 'sort_order', options_for_select([['Order of registration', planners_path],['Total of Consultations', planners_path(with_done_appointments: true)]],
-        selected: planners_path(with_done_appointments: params[:with_done_appointments])),
-        onchange: 'location = this.value;',
-        class: "form-control",
-        style: "height: 38px; margin: auto 0; line-height: 34px;"
+      = hidden_field_tag :sort, params[:sort]
+      = text_field_tag :name_cont, params[:name_cont], placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
+      = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px;"
 
+  - sort_options = [['Order of registration', planners_path(sort: 'order_of_registration', name_cont: params[:name_cont])],['Total of Consultations', planners_path(sort: 'total_of_consultations', name_cont: params[:name_cont])]]
 
+  div style="display: flex; align-items: center; margin-bottom: 20px;"
+    = select_tag 'sort_order',
+      options_for_select(sort_options, planners_path(sort: params[:sort], name_cont: params[:name_cont])),
+      onchange: 'location = this.value;',
+      class: "form-control",
+      style: "height: 38px; margin: auto 0; line-height: 34px;"
 
   .list-group
     - @planners.each do |planner|
@@ -24,6 +27,7 @@
           div style="display: flex; align-items: center; flex-grow: 1;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
             = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
+            = planner.id
             span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Consultations: #{done_count})"
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"
 

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -6,17 +6,20 @@
 
   = search_form_for @q, url: planners_path, method: :get do |f|
     div style="display: flex; align-items: center; margin-bottom: 20px;"
-      =f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
-      =f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: auto; hei"
+      = f.search_field :name_cont, placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
+      = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px; margin-right: 10px;"
+      = link_to 'Total sort', planners_path(with_done_appointments: true), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px; margin: auto 0; line-height: 34px;"
 
   .list-group
     - @planners.each do |planner|
+      - done_count = planner.count_done_appointment
       .list-group-item.d-flex.justify-content-between.align-items-center.mb-4 style="border: 1px solid #000; border-radius: 10px; padding: 15px; margin-bottom: 20px;"
-        .d-flex.align-items-center
-          div style="display: flex; align-items: center;"
+        .d-flex.align-items-center style="width: 100%;"
+          div style="display: flex; align-items: center; flex-grow: 1;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
-            = link_to truncate(planner.name, length: 20), planner_path(planner.id), class: 'planner-name-link'
-            = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px; margin-left: auto; margin-right: 30px;"
+            = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
+            span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total: #{done_count})"
+            = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"
 
   .pagination-wrapper
     = paginate @planners, window: 2
@@ -51,6 +54,6 @@ style
     }
 
     .pagination .current {
-      color: ##111111;
+      color: #111111;
       font-weight: bold;
     }

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -29,8 +29,6 @@
             = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
             - if params[:sort] == 'total_of_consultations'
               span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Consultations: #{done_count})"
-            - elsif params[:sort] == 'order_of_registration'
-              span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Registration Date: #{planner.created_at.strftime('%Y-%m-%d')})"
             - else
               span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Registration Date: #{planner.created_at.strftime('%Y-%m-%d')})"
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -21,7 +21,7 @@
 
   .list-group
     - @planners.each do |planner|
-      - done_count = planner.count_done_appointment
+      - done_count = planner.done_appointments_count
       .list-group-item.d-flex.justify-content-between.align-items-center.mb-4 style="border: 1px solid #000; border-radius: 10px; padding: 15px; margin-bottom: 20px;"
         .d-flex.align-items-center style="width: 100%;"
           div style="display: flex; align-items: center; flex-grow: 1;"

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -27,7 +27,12 @@
           div style="display: flex; align-items: center; flex-grow: 1;"
             img src=planner.icon_path alt="Planner Icon" style="width: 40px; height: 40px; border-radius: 50%; margin-right: 15px;"
             = link_to "#{truncate(planner.name, length: 20)}", planner_path(planner.id), class: 'planner-name-link'
-            span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Consultations: #{done_count})"
+            - if params[:sort] == 'total_of_consultations'
+              span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Total of Consultations: #{done_count})"
+            - elsif params[:sort] == 'order_of_registration'
+              span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Registration Date: #{planner.created_at.strftime('%Y-%m-%d')})"
+            - else
+              span style="margin-left: auto; color: gray; font-weight: bold; margin-right: 20px; font-size: 1.2em;" = "(Registration Date: #{planner.created_at.strftime('%Y-%m-%d')})"
             = link_to 'Reserve', planner_schedules_path(planner.id), class: 'btn btn-primary', style: "background-color: #4EA1D3; color: white; padding: 10px 50px; border-radius: 5px;"
 
   .pagination-wrapper

--- a/fp_app/app/views/planners/index.html.slim
+++ b/fp_app/app/views/planners/index.html.slim
@@ -10,11 +10,9 @@
       = text_field_tag :name_cont, params[:name_cont], placeholder: "Search by planner name", class: "form-control", style: "margin-right: 10px; height: 38px;"
       = f.submit "Search", class: "btn btn-primary", style: "background-color: #4EA1D3; color: white; border-radius: 5px; padding: 0 20px; height: 38px;"
 
-  - sort_options = [['Order of registration', planners_path(sort: 'order_of_registration', name_cont: params[:name_cont])],['Total of Consultations', planners_path(sort: 'total_of_consultations', name_cont: params[:name_cont])]]
-
   div style="display: flex; align-items: center; margin-bottom: 20px;"
     = select_tag 'sort_order',
-      options_for_select(sort_options, planners_path(sort: params[:sort], name_cont: params[:name_cont])),
+      options_for_select(sort_option(params), planners_path(sort: params[:sort], name_cont: params[:name_cont])),
       onchange: 'location = this.value;',
       class: "form-control",
       style: "height: 38px; margin: auto 0; line-height: 34px;"

--- a/fp_app/db/seeds.rb
+++ b/fp_app/db/seeds.rb
@@ -26,7 +26,6 @@ schedule_times = [
   { started_at: (Time.now.beginning_of_week + 1.week) + 17.hours, is_available: true }
 ]
 
-# すべてのプランナーにスケジュールを追加
 Planner.all.each do |planner|
   schedule_times.each do |time|
     Schedule.create!(
@@ -37,4 +36,17 @@ Planner.all.each do |planner|
   end
 end
 
-puts "100 planners and their schedules created successfully."
+Planner.all.sample(20).each do |planner|
+  rand(1..5).times do
+    schedule = planner.schedules.sample
+    Appointment.create!(
+      user: user,
+      planner: planner,
+      schedule: schedule,
+      reserved_at: schedule.started_at,
+      status: "done"
+    )
+  end
+end
+
+puts "100 planners, their schedules, and random appointments for random planners created successfully."

--- a/fp_app/spec/requests/planners/schedules_spec.rb
+++ b/fp_app/spec/requests/planners/schedules_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "Planners::Schedules", type: :request do
   let(:available_schedule) { create(:schedule, :reserved_schedule, planner: planner) }
 
   describe "GET /planners/:planner_id/schedule" do
-
     before do
       sign_in planner
     end
@@ -29,7 +28,6 @@ RSpec.describe "Planners::Schedules", type: :request do
   end
 
   describe "POST /planners/:planner_id/schedules" do
-
     before do
       sign_in planner
     end
@@ -57,7 +55,6 @@ RSpec.describe "Planners::Schedules", type: :request do
   end
 
   describe "PATCH /planners/:planner_id/schedules/:id/" do
-
     before do
       sign_in planner
     end
@@ -86,7 +83,6 @@ RSpec.describe "Planners::Schedules", type: :request do
 
   describe "PATCH /schedules/:id" do
     context "when schedule is associated with a reserved appointment" do
-
       before do
         sign_in user
       end


### PR DESCRIPTION
plannerを登録順と、過去の総相談回数順でソートできるようにしました。
以下に実際の動作動画を示します。

---------------------------------------------------------------------------------------------------------------
https://github.com/user-attachments/assets/435d75da-825d-46ea-8577-5b604525254c

---------------------------------------------------------------------------------------------------------------
今回追加したソート機能と前回のPRで追加した名前の検索機能は互いに連携されていて、
ソートした後の検索、
検索した後のソート
の動作も上の動画で確認済みです。

今回確認をお願いしたいファイルを以下に示します。

- fp_app/app/models/planner.rb
- fp_app/app/controllers/planners_controller.rb
- fp_app/app/views/planners/index.html.slim

---------------------------------------------------------------------------------------------------------------
よろしくお願いします🙇

