### PR TITLE
Display error message on schedule

### DIFF
--- a/fp_app/app/controllers/planners/schedules_controller.rb
+++ b/fp_app/app/controllers/planners/schedules_controller.rb
@@ -37,8 +37,9 @@ class Planners::SchedulesController < ApplicationController
           format.js { render "planners/schedules/update_schedule" }
         end
       else
+        error_message = @schedule.errors.full_messages.join(", ")
         respond_to do |format|
-          format.js { render js: "alert('Unable to update availability.');" }
+          format.js { render js: "alert(`Unable to update schedule: #{error_message}`);" }
         end
       end
     end
@@ -55,8 +56,9 @@ class Planners::SchedulesController < ApplicationController
         format.js { render "planners/schedules/update_schedule" }
       end
     else
+      error_message = @schedule.errors.full_messages.join(", ")
       respond_to do |format|
-        format.js { render js: "alert('Unable to create schedule.');" }
+        format.js { render js: "alert(`Unable to create schedule: #{error_message}`);" }
       end
     end
   end


### PR DESCRIPTION
plannerがスケジュールの作成、更新に失敗したとき、モデルからのエラー文を全文表示させるようにしました。
以下に実装後のエラー画面のスクリーンショットを添付します。

<img width="1370" alt="スクリーンショット 2024-12-02 17 41 24" src="https://github.com/user-attachments/assets/7bbe9179-096e-4d65-a91a-b625b87634e4">

---
今まではUnable to update schedule:までしか表示されていませんでいたが、エラー文全文が表示されるようになっています。
今回確認をお願いしたいファイルは以下の１つです。

- app/controllers/planners/schedules_controller.rb

確認よろしくお願いします🙇