### PR TITLE
Adjust error message position on registration page

### DIFF
--- a/fp_app/app/views/planners/registrations/new.html.slim
+++ b/fp_app/app/views/planners/registrations/new.html.slim
@@ -1,12 +1,14 @@
 h1[style="text-align: center; margin-bottom: 30px;"]
-  img src=asset_path('title_icon.png') alt="icon" style="vertical-align: middle; margin-right: 10px; width: 45px; height: 45px;"
-  | Reservation App
+  |  <img src="
+  = asset_path('title_icon.png')
+  | " alt="icon" style="vertical-align: middle; margin-right: 10px; width: 45px; height: 45px;"> Reservation App
 
 h2[style="text-align: center; margin-bottom: 30px;"]
   | Planner Sign up
 
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render "users/shared/error_messages", resource: resource
+  .error-messages[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]
+    = render "users/shared/error_messages", resource: resource
 
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]
     = f.label :email.downcase, style: "display: block; margin-bottom: 5px;"
@@ -18,7 +20,7 @@ h2[style="text-align: center; margin-bottom: 30px;"]
       em
         | (
         = @minimum_password_length
-        | characters minimum)
+        |  characters minimum)
     = f.password_field :password, autocomplete: "new-password", class: "form-control", style: "width: 100%;"
 
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]

--- a/fp_app/app/views/planners/registrations/new.html.slim
+++ b/fp_app/app/views/planners/registrations/new.html.slim
@@ -20,7 +20,7 @@ h2[style="text-align: center; margin-bottom: 30px;"]
       em
         | (
         = @minimum_password_length
-        |  characters minimum)
+        | characters minimum)
     = f.password_field :password, autocomplete: "new-password", class: "form-control", style: "width: 100%;"
 
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]

--- a/fp_app/app/views/users/registrations/new.html.slim
+++ b/fp_app/app/views/users/registrations/new.html.slim
@@ -5,10 +5,13 @@ h1[style="text-align: center; margin-bottom: 30px;"]
 h2[style="text-align: center; margin-bottom: 30px;"]
   | User Sign up
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-  = render "users/shared/error_messages", resource: resource
+  .error-messages[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]
+    = render "users/shared/error_messages", resource: resource
+
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]
     = f.label :email.downcase, style: "display: block; margin-bottom: 5px;"
     = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", style: "width: 100%;"
+
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]
     = f.label :password.downcase, style: "display: block; margin-bottom: 5px;"
     - if @minimum_password_length
@@ -17,13 +20,14 @@ h2[style="text-align: center; margin-bottom: 30px;"]
         = @minimum_password_length
         |  characters minimum)
     = f.password_field :password, autocomplete: "new-password", class: "form-control", style: "width: 100%;"
+
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]
     = f.label :password_confirmation.downcase, style: "display: block; margin-bottom: 5px;"
     = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control", style: "width: 100%;"
+
   .actions[style="width: 60%; margin-left: auto; margin-right: auto; display: flex; justify-content: space-between; margin-top: 20px; margin-bottom: 20px;"]
     = link_to "Log in", new_session_path(resource_name), style: "color: #DDA0DD; padding: 5px 0px; display: inline-block; text-decoration: none; border: 1px solid transparent; margin-top: 10px; margin-bottom: 10px;"
     = f.submit "Create my account", class: "btn btn-primary", style: "width: auto; padding: 5px 15px; margin-top: 10px; margin-bottom: 10px;"
-
 
   .actions[style="width: 60%; margin-left: auto; margin-right: auto; display: flex; justify-content: space-between; margin-top: 20px; margin-bottom: 20px;"]
     = link_to "I'm a planner", new_planner_registration_path, style: "color: #DDA0DD; padding: 5px 0px; display: inline-block; text-decoration: none; border: 1px solid transparent; margin-top: 10px; margin-bottom: 10px;"

--- a/fp_app/app/views/users/registrations/new.html.slim
+++ b/fp_app/app/views/users/registrations/new.html.slim
@@ -18,7 +18,7 @@ h2[style="text-align: center; margin-bottom: 30px;"]
       em
         | (
         = @minimum_password_length
-        |  characters minimum)
+        | characters minimum)
     = f.password_field :password, autocomplete: "new-password", class: "form-control", style: "width: 100%;"
 
   .field[style="margin-bottom: 20px; width: 60%; margin-left: auto; margin-right: auto;"]


### PR DESCRIPTION
user, planner両方の新規登録ページでエラー文の出力の位置を調整しました。
以下に実装前と実装後の登録画面を添付します。

### 実装前

<img width="1461" alt="スクリーンショット 2024-12-02 17 58 24" src="https://github.com/user-attachments/assets/eb073dcd-5b40-4c86-a81a-63b459d9d6eb">

画像のようにエラー文の左端の位置が入力フィールドの左端の位置と大きくずれています。

---
### 実装後
<img width="1027" alt="スクリーンショット 2024-12-02 17 59 01" src="https://github.com/user-attachments/assets/b42e7058-e2df-48d8-a7dd-d26178774a7d">

実装後は左端の位置が揃っていることが確認できます。

---
今回確認をお願いしたいファイルは以下の２つです。

- app/views/users/registrations/new.html.slim
- app/views/planners/registrations/new.html.slim

よろしくお願いします🙇