### PR TITLE
delete-time-from-calendar

### DIFF
--- a/fp_app/app/views/simple_calendar/_appointment_week_calendar.html.slim
+++ b/fp_app/app/views/simple_calendar/_appointment_week_calendar.html.slim
@@ -26,7 +26,7 @@
     table.table.table-bordered.table-striped
       thead
         tr
-          th[style="text-align: center; vertical-align: middle;"] 時間
+          th[style="text-align: center; vertical-align: middle;"]
           - date_range.slice(0, 7).each do |day|
             - unless day.sunday?
               th[style="text-align: center; font-weight: bold;"]

--- a/fp_app/app/views/simple_calendar/_week_calendar.html.slim
+++ b/fp_app/app/views/simple_calendar/_week_calendar.html.slim
@@ -8,7 +8,7 @@ div.simple-calendar
   table.table.table-bordered.table-striped
     thead
       tr
-        th [style="text-align: center; vertical-align: middle;"]時間
+        th [style="text-align: center; vertical-align: middle;"]
         - date_range.slice(0, 7).each do |day|
           - unless day.wday == 0
             th[style="text-align: center; font-weight: bold;"]


### PR DESCRIPTION
アプリの中での言語を英語で揃えていましたが、カレンダー表示ページのカレンダー部分に、日本語で「時間」と書かれていた部分があったので、修正を加えました。
「時間」→「Time」としても良かったのですが、ここは表記がない方が見やすくなると思い、表記ごと削除しました。
以下にこの変更前と変更後でのviewの変更箇所を示します。

 ### 変更前
<img width="1224" alt="スクリーンショット 2024-12-18 17 14 33" src="https://github.com/user-attachments/assets/447f1264-dc0d-4bf9-b849-01742d353458" />

カレンダー部分に「時間」と日本語で表記があります。

### 変更後
<img width="1230" alt="スクリーンショット 2024-12-18 17 18 44" src="https://github.com/user-attachments/assets/c31235c8-20f7-4740-895d-5d47ea664a0f" />

この部分の表記ごと削除しました。

確認よろしくお願いします🙇